### PR TITLE
Update: prevent superfluous set updates

### DIFF
--- a/js/adapt-contrib-scoring.js
+++ b/js/adapt-contrib-scoring.js
@@ -83,9 +83,10 @@ class Scoring extends Backbone.Controller {
    * @fires Adapt#scoring:update
    */
   update() {
-    const updateSubsets = !this._queuedChanges?.length
+    const queuedChanges = [...new Set(this._queuedChanges)];
+    const updateSubsets = !queuedChanges?.length
       ? this.subsets
-      : this._queuedChanges.reduce((updateSubsets, model) => updateSubsets.concat(getSubsetsByModelId(model?.get('_id'))), []);
+      : queuedChanges.reduce((subsets, model) => subsets.concat(getSubsetsByModelId(model?.get('_id'))), []);
     updateSubsets.forEach(set => set.update());
     this._queuedChanges = [];
     if (!updateSubsets.length) return;

--- a/js/adapt-contrib-scoring.js
+++ b/js/adapt-contrib-scoring.js
@@ -86,7 +86,7 @@ class Scoring extends Backbone.Controller {
     const queuedChanges = [...new Set(this._queuedChanges)];
     const updateSubsets = !queuedChanges?.length
       ? this.subsets
-      : queuedChanges.reduce((subsets, model) => subsets.concat(getSubsetsByModelId(model?.get('_id'))), []);
+      : [...new Set(queuedChanges.reduce((subsets, model) => subsets.concat(getSubsetsByModelId(model?.get('_id'))), []))];
     updateSubsets.forEach(set => set.update());
     this._queuedChanges = [];
     if (!updateSubsets.length) return;


### PR DESCRIPTION
Fixes #17.

### Update
* Prevent superfluous set updates by removing duplicates from the queue and intersection lookups.